### PR TITLE
adds requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyparsing==2.0.1
+numpy==1.7.0


### PR DESCRIPTION
added a requirements file because I had problems debugging a new install on my local machine and the problem turned out to be I had the wrong version of pyparsing installed. 